### PR TITLE
Enhanced support for failover transport

### DIFF
--- a/activemq-transport/src/main/java/com/esri/geoevent/transport/activemq/ActiveMQInboundTransport.java
+++ b/activemq-transport/src/main/java/com/esri/geoevent/transport/activemq/ActiveMQInboundTransport.java
@@ -44,6 +44,8 @@ import javax.jms.Session;
 import javax.jms.TextMessage;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.ActiveMQConnection;
+import org.apache.activemq.transport.TransportListener;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -70,6 +72,41 @@ public class ActiveMQInboundTransport extends InboundTransportBase implements Ru
   @Override
   public void run()
   {
+    if (connection == null)
+    {
+      errorMessage = "ActiveMQ input transport thread started with uninitialized connection";
+      log.error("ActiveMQ input transport thread started with uninitialized connection");
+      setRunningState(RunningState.STOPPING);
+      cleanup();
+      setRunningState(RunningState.ERROR);
+      return;
+    }
+    
+    try
+    {
+      connection.start();
+      session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+      ActiveMQDestinationType type = com.esri.ges.util.Validator.validateEnum(ActiveMQDestinationType.class, getProperty("destinationType").getValueAsString(), ActiveMQDestinationType.Queue);
+      messageConsumer = session.createConsumer(type.equals(ActiveMQDestinationType.Topic) ? session.createTopic(getProperty("destinationName").getValueAsString()) : session.createQueue(getProperty("destinationName").getValueAsString()));
+    }
+    catch (JMSException exception)
+    {
+      String exceptionMessage = exception.getMessage();
+      if (exceptionMessage.equals("Stopped."))
+      {
+        log.trace("JMS Exception \"Stopped.\" occurred during initialization of transport service thread. This may occur if the input is stopped manually before the connection has completed.");
+      }
+      else
+      {
+        errorMessage = exceptionMessage;
+        log.error("JMS Exception - " + errorMessage, exception);
+        setRunningState(RunningState.STOPPING);
+        cleanup();
+        setRunningState(RunningState.ERROR);
+      }
+      return;
+    }
+    
     setRunningState(RunningState.STARTED);
     while (isRunning())
     {
@@ -201,16 +238,20 @@ public class ActiveMQInboundTransport extends InboundTransportBase implements Ru
   {
     try
     {
+      ActiveMQConnectionFactory factory = new ActiveMQConnectionFactory(getProperty("providerUrl").getValueAsString());
       if (getProperty("userName") != null && getProperty("password") != null)
       {
-        ConnectionFactory factory = new ActiveMQConnectionFactory(getProperty("userName").getValueAsString(), getProperty("password").getDecryptedValue(), getProperty("providerUrl").getValueAsString());
-        connection = factory.createConnection(getProperty("userName").getValueAsString(), getProperty("password").getDecryptedValue());
+        try
+        {
+          factory.setUserName(getProperty("userName").getValueAsString());
+          factory.setPassword(getProperty("password").getDecryptedValue());
+        }
+        catch (Exception e)
+        {
+          throw new TransportException("Password encrypted property access failed - " + e.getMessage());
+        }
       }
-      else
-      {
-        ConnectionFactory factory = new ActiveMQConnectionFactory(getProperty("providerUrl").getValueAsString());
-        connection = factory.createConnection();
-      }
+      connection = factory.createConnection();
       if (connection == null)
         throw new TransportException("Could not establish a JMS Connection to " + getProperty("providerUrl").getValueAsString());
       connection.setExceptionListener(new ExceptionListener()
@@ -225,20 +266,47 @@ public class ActiveMQInboundTransport extends InboundTransportBase implements Ru
           log.error(errorMessage);
         }
       });
-      connection.start();
-      session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-      ActiveMQDestinationType type = com.esri.ges.util.Validator.validateEnum(ActiveMQDestinationType.class, getProperty("destinationType").getValueAsString(), ActiveMQDestinationType.Queue);
-      messageConsumer = session.createConsumer(type.equals(ActiveMQDestinationType.Topic) ? session.createTopic(getProperty("destinationName").getValueAsString()) : session.createQueue(getProperty("destinationName").getValueAsString()));
+      ActiveMQConnection amqConn = (ActiveMQConnection)connection;
+      if (amqConn.getTransport().isFaultTolerant()) {
+        amqConn.addTransportListener(new TransportListener()
+        {
+          private boolean wasStarted = false;
+          @Override
+          public void onCommand(Object command) {
+            // ignore
+          }
+          @Override
+          public void onException(IOException exception) {
+            log.warn("ActiveMQ input transport - IO exception - " + exception.getMessage());
+          }
+          @Override
+          public void transportInterupted()
+          {
+            log.warn("ActiveMQ input transport - connection interrupted");
+            if (RunningState.STARTED.equals(getRunningState()))
+            {
+              setRunningState(RunningState.STARTING);
+              wasStarted = true;
+            }
+          }
+          @Override
+          public void transportResumed()
+          {
+            log.warn("ActiveMQ input transport - connection resumed");
+            if (wasStarted && RunningState.STARTING.equals(getRunningState()))
+            {
+              setRunningState(RunningState.STARTED);
+            }
+          }
+        });
+      }
+      // connection should be ready to start(), but it may block indefinitely, so the rest is moved into run()
     }
     catch (JMSException e)
     {
       cleanup();
-      throw new TransportException(e.getMessage());
-    }
-    catch (Exception e)
-    {
-      cleanup();
-      throw new TransportException(e.getMessage());
+      setRunningState(RunningState.ERROR);
+      throw new TransportException("ActiveMQ connection setup failed - " + e.getMessage());
     }
   }
 

--- a/activemq-transport/src/main/java/com/esri/geoevent/transport/activemq/ActiveMQInboundTransport.java
+++ b/activemq-transport/src/main/java/com/esri/geoevent/transport/activemq/ActiveMQInboundTransport.java
@@ -94,7 +94,7 @@ public class ActiveMQInboundTransport extends InboundTransportBase implements Ru
       String exceptionMessage = exception.getMessage();
       if (exceptionMessage.equals("Stopped."))
       {
-        log.trace("JMS Exception \"Stopped.\" occurred during initialization of transport service thread. This may occur if the input is stopped manually before the connection has completed.");
+        log.warn("JMS Exception \"Stopped.\" during initialization of transport service thread. This may occur if the input is stopped before completing the connection.");
       }
       else
       {
@@ -270,7 +270,6 @@ public class ActiveMQInboundTransport extends InboundTransportBase implements Ru
       if (amqConn.getTransport().isFaultTolerant()) {
         amqConn.addTransportListener(new TransportListener()
         {
-          private boolean wasStarted = false;
           @Override
           public void onCommand(Object command) {
             // ignore
@@ -283,20 +282,11 @@ public class ActiveMQInboundTransport extends InboundTransportBase implements Ru
           public void transportInterupted()
           {
             log.warn("ActiveMQ input transport - connection interrupted");
-            if (RunningState.STARTED.equals(getRunningState()))
-            {
-              setRunningState(RunningState.STARTING);
-              wasStarted = true;
-            }
           }
           @Override
           public void transportResumed()
           {
             log.warn("ActiveMQ input transport - connection resumed");
-            if (wasStarted && RunningState.STARTING.equals(getRunningState()))
-            {
-              setRunningState(RunningState.STARTED);
-            }
           }
         });
       }


### PR DESCRIPTION
When working with the failover transport for automated recovery with ActiveMQ, I found that if no broker was available when the input was first started, it would get stuck in a STARTING state and would be unresponsive e.g. could not be stopped or reconfigured, remaining in that state until it finally established a connection.

The issue seemed to be that connection.start() was being called from setup() before the transport thread was created. This can block indefinitely, e.g. if no broker is available when the input is first starting up.

In this change, by only initializing the connection to a ready-to-start state in setup() but leaving it for the transport thread to call start() and create the session etc. from inside run(), the problem seems to be avoided and the input remains manageable / stoppable even before it reaches the STARTED state.

I also added Manager-visible log messages and status indicators to report on failover events. These were not directly needed to address the issue noted above, but proved useful for monitoring in Manager. The same commit also includes an unrelated change to username / password handling, not specific to failover - sorry about that.

I don't know if it occurred prior to these changes, but I noticed that occasionally a message would appear after I started an input, saying that an error occurred. I would then find the input was successfully started after all and was receiving messages. I'm not sure what is causing that. At any rate, no other run-time issues were noted.
