### PR TITLE
Update component version to 10.4.1, GeoEvent dependency to 10.4.1+, ActiveMQ to 5.16.0

### DIFF
--- a/activemq-transport/pom.xml
+++ b/activemq-transport/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.esri.geoevent.parent</groupId>
     <artifactId>activemq</artifactId>
-    <version>10.6.1</version>
+    <version>10.8.1</version>
   </parent>
   <groupId>com.esri.geoevent.transport</groupId>
   <artifactId>activemq-transport</artifactId>

--- a/activemq-transport/pom.xml
+++ b/activemq-transport/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.esri.geoevent.parent</groupId>
     <artifactId>activemq</artifactId>
-    <version>10.8.1</version>
+    <version>10.4.1</version>
   </parent>
   <groupId>com.esri.geoevent.transport</groupId>
   <artifactId>activemq-transport</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,7 @@
 
   <groupId>com.esri.geoevent.parent</groupId>
   <artifactId>activemq</artifactId>
-
   <version>10.4.1</version>
-
   <packaging>pom</packaging>
 
   <name>Esri :: GeoEvent :: ActiveMQ</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,9 @@
 
   <groupId>com.esri.geoevent.parent</groupId>
   <artifactId>activemq</artifactId>
-  <version>10.6.1</version>
+
+  <version>10.8.1</version>
+
   <packaging>pom</packaging>
 
   <name>Esri :: GeoEvent :: ActiveMQ</name>
@@ -14,8 +16,11 @@
   <properties>
     <contact.address>geoevent@esri.com</contact.address>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.bundle.plugin.version>3.5.0</maven.bundle.plugin.version>
-    <activemq.version>5.15.10</activemq.version>
+    <maven.bundle.plugin.version>4.2.1</maven.bundle.plugin.version>
+
+    <activemq.version>5.16.0</activemq.version>
+
+    <geoevent.compat.version>10.4.1</geoevent.compat.version>
   </properties>
 
   <modules>
@@ -35,7 +40,7 @@
     <dependency>
       <groupId>com.esri.geoevent.sdk</groupId>
       <artifactId>geoevent-sdk</artifactId>
-      <version>${project.version}</version>
+      <version>[{geoevent.compat.version},)</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -43,7 +48,30 @@
       <artifactId>activemq-client</artifactId>
       <version>${activemq.version}</version>
     </dependency>
-    <!-- dependencies for embedding via the vm and peer transports omitted -->
+    <!-- dependencies for embedding via the vm and peer transports included -->
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-broker</artifactId>
+      <version>${activemq.version}</version>
+    </dependency>
+
+    <!-- although dependencies for persistent store are included, in most
+         cases best to use persistent=false in the vm or peer broker URL -->
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-kahadb-store</artifactId>
+      <version>${activemq.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-jdbc-store</artifactId>
+      <version>${activemq.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
     <!-- rely on transitive dependencies for right version of slf4j etc. -->
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>com.esri.geoevent.parent</groupId>
   <artifactId>activemq</artifactId>
 
-  <version>10.8.1</version>
+  <version>10.4.1</version>
 
   <packaging>pom</packaging>
 
@@ -17,10 +17,7 @@
     <contact.address>geoevent@esri.com</contact.address>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.bundle.plugin.version>4.2.1</maven.bundle.plugin.version>
-
     <activemq.version>5.16.0</activemq.version>
-
-    <geoevent.compat.version>10.4.1</geoevent.compat.version>
   </properties>
 
   <modules>
@@ -40,7 +37,7 @@
     <dependency>
       <groupId>com.esri.geoevent.sdk</groupId>
       <artifactId>geoevent-sdk</artifactId>
-      <version>[{geoevent.compat.version},)</version>
+      <version>[{project.version},)</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -48,31 +45,6 @@
       <artifactId>activemq-client</artifactId>
       <version>${activemq.version}</version>
     </dependency>
-    <!-- dependencies for embedding via the vm and peer transports included -->
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-broker</artifactId>
-      <version>${activemq.version}</version>
-    </dependency>
-
-    <!-- although dependencies for persistent store are included, in most
-         cases best to use persistent=false in the vm or peer broker URL -->
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-kahadb-store</artifactId>
-      <version>${activemq.version}</version>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-jdbc-store</artifactId>
-      <version>${activemq.version}</version>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
-
-    <!-- rely on transitive dependencies for right version of slf4j etc. -->
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.esri.geoevent.sdk</groupId>
       <artifactId>geoevent-sdk</artifactId>
-      <version>[{project.version},)</version>
+      <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This is mostly a dependency update:

- OSGI bundle version updated to 10.4.1 (also the component version in GeoEvent Manager)

- ActiveMQ version 5.16.0 (removing commented-out dependencies required for embedded peer or vm broker)

(comment updated to reflect current state)