### PR TITLE
Update ActiveMQ to 5.16.4, minor version increment with security fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <contact.address>geoevent@esri.com</contact.address>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.bundle.plugin.version>4.2.1</maven.bundle.plugin.version>
-    <activemq.version>5.16.0</activemq.version>
+    <activemq.version>5.16.4</activemq.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
This version includes updated dependencies to reference reload4j instead of log4j 1.2.x, to address several recently uncovered vulnerabilities. None of these vulnerabilities impacts the normal usage of the transport with a typical tcp: or failover: ActiveMQ connection URI.

ActiveMQ for GeoEvent was already running an earlier 5.16.x release, so updating to this version is not likely to have any impact on previously configured GeoEvent inputs / outputs, but as always, it is recommended to take a backup of the current config before updating the transport.