### PR TITLE
Update ActiveMQ to 5.16.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,14 +26,8 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging</artifactId>
-        <version>1.2</version>
-      </dependency>
-      <dependency>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
-          <version>1.7.36</version>
           <scope>provided</scope>
       </dependency>
     </dependencies>
@@ -45,19 +39,6 @@
       <artifactId>geoevent-sdk</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-      </exclusions> 
-    </dependency>
-    <dependency>
-        <groupId>ch.qos.reload4j</groupId>
-        <artifactId>reload4j</artifactId>
-        <version>1.2.19</version>
-        <scope>provided</scope>
-        <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
     <contact.address>geoevent@esri.com</contact.address>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.bundle.plugin.version>4.2.1</maven.bundle.plugin.version>
-    <activemq.version>5.16.0</activemq.version>
+    <activemq.version>5.16.4</activemq.version>
+    <!-- can't go to 5.17 if GeoEvent is running under JRE8 - which 10.8.x and earlier do -->
   </properties>
 
   <modules>
@@ -27,16 +28,33 @@
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.1.1</version>
+        <version>1.2</version>
       </dependency>
-    </dependencies>
+      <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <version>1.7.36</version>
+      </dependency>
+      </dependencies>
   </dependencyManagement>
+  
   <dependencies>
     <dependency>
       <groupId>com.esri.geoevent.sdk</groupId>
       <artifactId>geoevent-sdk</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions> 
+    </dependency>
+    <dependency>
+        <groupId>ch.qos.reload4j</groupId>
+        <artifactId>reload4j</artifactId>
+        <version>1.2.19</version>
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
@@ -44,7 +62,6 @@
       <version>${activemq.version}</version>
     </dependency>
   </dependencies>
-
   <build>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.bundle.plugin.version>4.2.1</maven.bundle.plugin.version>
     <activemq.version>5.16.4</activemq.version>
-    <!-- can't go to 5.17 if GeoEvent is running under JRE8 - which 10.8.x and earlier do -->
+    <!-- can't go to 5.17 if ArcGIS GeoEvent Server is running under JRE8 - which it does in 10.8.x and earlier -->
   </properties>
 
   <modules>
@@ -26,9 +26,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-          <scope>provided</scope>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <scope>provided</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,9 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
           <version>1.7.36</version>
+          <scope>provided</scope>
       </dependency>
-      </dependencies>
+    </dependencies>
   </dependencyManagement>
   
   <dependencies>
@@ -55,6 +56,8 @@
         <groupId>ch.qos.reload4j</groupId>
         <artifactId>reload4j</artifactId>
         <version>1.2.19</version>
+        <scope>provided</scope>
+        <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>


### PR DESCRIPTION
This updates ActiveMQ to the recently released version 5.16.4, to get the latest and most stable version of ActiveMQ Client that runs on both JRE8 and later JREs. It replaces of log4j 1.2.x with reload4j, although not sure if this affects the client.

In addition, slf4j is updated to the latest version, which uses reload4j in lieu of log4j 1.2.x, and an exclusion is added to the GeoEvent SDK dependency to ensure that the original log4j 1.2.x does not get pulled at build time. Finally, an explicit dependency for reload4j was also added, just to be sure.

After this change, I confirmed that log4j no longer appears in the compile-time dependencies as shown in NetBeans; and the classes for the explicitly selected versions of slf4j and reload4j are present in the resulting JAR, ensuring that ActiveMQ for GeoEvent will use these classes in preference to any that may be provided by GeoEvent Server itself.

It is unknown whether the use of ActiveMQ for GeoEvent could ever lead to any problems with log4j 1.2.x vulnerabilities. However, many organizations have a goal to eliminate any chance of exposure to known log4j 1.2.x and 2.x vulnerabilities.

Incidentally, ActiveMQ 5.17 has just been released as well, with many bug fixes and improvements. However, we can't use that in ActiveMQ for GeoEvent, because GeoEvent Server 10.8.x and earlier run under JRE8, which is no longer supported for ActiveMQ 5.17. (I know this from the mailing lists; it doesn't seem to be prominently mentioned in the release announcement.)