### PR TITLE
Add missing strings in resources for TS and KS label / description

### DIFF
--- a/activemq-transport/src/main/resources/com/esri/geoevent/transport/activemq-transport.properties
+++ b/activemq-transport/src/main/resources/com/esri/geoevent/transport/activemq-transport.properties
@@ -12,6 +12,15 @@ TRANSPORT_IN_USERNAME_DESC=The user name of the credentials for the ActiveMQ ser
 TRANSPORT_IN_PASSWORD_LBL=Password
 TRANSPORT_IN_PASSWORD_DESC=The password of the credentials for the ActiveMQ server
 
+TRANSPORT_IN_ARTEMIS_TS_PATH_LBL=Trust Store Path
+TRANSPORT_IN_ARTEMIS_TS_PATH_DESC=Path to the Trust Store, if needed for a secure broker connection
+TRANSPORT_IN_ARTEMIS_KS_PATH_LBL=Key Store Path
+TRANSPORT_IN_ARTEMIS_KS_PATH_DESC=Path to the Key Store, if needed for a secure broker connection
+TRANSPORT_IN_ARTEMIS_TS_PASSWD_LBL=Trust Store Password
+TRANSPORT_IN_ARTEMIS_TS_PASSWD_DESC=Password for the Trust Store, if needed for a secure broker connection
+TRANSPORT_IN_ARTEMIS_KS_PASSWD_LBL=Key Store Password
+TRANSPORT_IN_ARTEMIS_KS_PASSWD_DESC=Password for the Key Store, if needed for a secure broker connection
+
 # Outbound Transport Definition
 TRANSPORT_OUT_LABEL=ActiveMQ Outbound Transport
 TRANSPORT_OUT_DESC=JMS Outbound Transport for connecting to ActiveMQ message servers.


### PR DESCRIPTION
I noticed that, if I attempt to define a new Connector, there are properties for the Key Store and Trust Store that did not expand properly to an English label and description.

Looking back at the PR #9 where the trust store and key store properties were added, it appears the properties file under resources was missing from the commit, even though it was probably updated in the contributor's local code. To remedy this, I added a label and description for each of the new properties, using the names that were in the Java code.

Note, I did not include Artemis in the label and description text, as I believe these properties should work equally well with an ActiveMQ Classic broker.