### PR TITLE
Update maven plugins to work with later JDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <contact.address>geoevent@esri.com</contact.address>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.bundle.plugin.version>4.2.1</maven.bundle.plugin.version>
+    <maven.bundle.plugin.version>5.1.8</maven.bundle.plugin.version>
     <activemq.version>5.16.5</activemq.version>
     <!--
     This will be the final release of ActiveMQ 5.16.x.
@@ -22,6 +22,18 @@
     ArcGIS GeoEvent Server 10.9.x or above at runtime.
     -->
   </properties>
+  
+  <profiles>
+    <profile>
+      <id>cross-compile-from-later-jdk</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <maven.compiler.release>8</maven.compiler.release>
+      </properties>
+    </profile>
+  </profiles>
 
   <modules>
     <module>activemq-transport</module>
@@ -62,7 +74,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>2.5.1</version>
+          <version>3.10.1</version>
           <configuration>
             <source>1.8</source>
             <target>1.8</target>


### PR DESCRIPTION
Updated plugins and added profile to support building with newer JDKs, still with JRE 8 compatible output.

The maven.compiler.release property is generally needed to support cross compilation, and does more than the source and target properties. However, this property is not supported on JDK 1.8 - thus the need for a profile which only activates on later JDKs. See [this answer on Stack Overflow](https://stackoverflow.com/a/65655542) for more info. I also updated the compiler plugin from 2.5.1 to 3.10.1 as part of this change.

The Felix Maven Bundle Plugin also needed to be updated from 4.2.1 to the latest 5.1.8, due to a defect in the underlying BND tools, which first surfaced in JDK 15. See [this related issue](https://github.com/bndtools/bnd/issues/3903) for more info.

I tested building with JDK 17. The resulting JAR was tested on ArcGIS GeoEvent Server 10.8.1 but is intended to work on all releases from 10.4.1 through 11.x. (I also confirmed that it still builds on JDK 1.8, although I did not test-deploy that build.)