### PR TITLE
Update ActiveMQ client dependency to 5.16.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,11 @@
     <contact.address>geoevent@esri.com</contact.address>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.bundle.plugin.version>4.2.1</maven.bundle.plugin.version>
-    <activemq.version>5.16.5</activemq.version>
+    <activemq.version>5.16.6</activemq.version>
     <!--
-    This will be the final release of ActiveMQ 5.16.x.
+    This will be the absolute final release of ActiveMQ 5.16.x,
+    and as such the last version of ActiveMQ client to support
+    JRE 8, which is used in ArcGIS GeoEvent Server 10.8.1 and older.
     Upgrading to ActiveMQ 5.17.x or above will require
     ArcGIS GeoEvent Server 10.9.x or above at runtime.
     -->


### PR DESCRIPTION
A final update of ActiveMQ 5.16.x has been released, containing important bug fixes and dependency updates. Note that later versions of ActiveMQ, e.g. 5.17.x, require Java 11+ and are therefore not compatible with GeoEvent Server 10.4.1-10.8.1.

This PR may require manual merging with #18, due to changes on adjacent lines of the parent pom file. However, the changes are compatible, and the change from this PR has been tested both with and without #18.